### PR TITLE
[FOLLOWUP-5] Mock OFT to aid in migrating liquidity

### DIFF
--- a/plume-oft-adapter-migration/contracts/plume/PlumeOFTMock.sol
+++ b/plume-oft-adapter-migration/contracts/plume/PlumeOFTMock.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.22;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { OFT } from "@layerzerolabs/oft-evm/contracts/OFT.sol";
+
+contract PlumeOFTMock is OFT {
+    constructor(
+        string memory _name,
+        string memory _symbol,
+        address _lzEndpoint,
+        address _delegate
+    ) OFT(_name, _symbol, _lzEndpoint, _delegate) Ownable(_delegate) {}
+
+    function mint(address _to, uint256 _amount) public onlyOwner {
+        _mint(_to, _amount);
+    }
+}

--- a/plume-oft-adapter-migration/deploy/PlumeOFTMock.ts
+++ b/plume-oft-adapter-migration/deploy/PlumeOFTMock.ts
@@ -1,0 +1,53 @@
+import assert from 'assert'
+
+import { type DeployFunction } from 'hardhat-deploy/types'
+
+const contractName = 'PlumeOFTMock'
+
+const deploy: DeployFunction = async (hre) => {
+    const { getNamedAccounts, deployments } = hre
+
+    const { deploy } = deployments
+    const { deployer } = await getNamedAccounts()
+
+    assert(deployer, 'Missing named deployer account')
+
+    console.log(`Network: ${hre.network.name}`)
+    console.log(`Deployer: ${deployer}`)
+
+    // This is an external deployment pulled in from @layerzerolabs/lz-evm-sdk-v2
+    //
+    // @layerzerolabs/toolbox-hardhat takes care of plugging in the external deployments
+    // from @layerzerolabs packages based on the configuration in your hardhat config
+    //
+    // For this to work correctly, your network config must define an eid property
+    // set to `EndpointId` as defined in @layerzerolabs/lz-definitions
+    //
+    // For example:
+    //
+    // networks: {
+    //   'optimism-testnet': {
+    //     ...
+    //     eid: EndpointId.OPTSEP_V2_TESTNET
+    //   }
+    // }
+    const endpointV2Deployment = await hre.deployments.get('EndpointV2')
+
+    const { address } = await deploy(contractName, {
+        from: deployer,
+        args: [
+            'MyOFT', // name
+            'MOFT', // symbol
+            endpointV2Deployment.address, // LayerZero's EndpointV2 address
+            deployer, // owner
+        ],
+        log: true,
+        skipIfAlreadyDeployed: false,
+    })
+
+    console.log(`Deployed contract: ${contractName}, network: ${hre.network.name}, address: ${address}`)
+}
+
+deploy.tags = [contractName]
+
+export default deploy

--- a/plume-oft-adapter-migration/hardhat.config.ts
+++ b/plume-oft-adapter-migration/hardhat.config.ts
@@ -58,14 +58,14 @@ const config: HardhatUserConfig = {
         ],
     },
     networks: {
-        'optimism-testnet': {
-            eid: EndpointId.OPTSEP_V2_TESTNET,
-            url: process.env.RPC_URL_OP_SEPOLIA || 'https://optimism-sepolia.gateway.tenderly.co',
+        'ethereum-mainnet': {
+            eid: EndpointId.ETHEREUM_V2_MAINNET,
+            url: process.env.RPC_URL_ETH_MAINNET || 'https://1rpc.io/eth',
             accounts,
         },
-        'arbitrum-testnet': {
-            eid: EndpointId.ARBSEP_V2_TESTNET,
-            url: process.env.RPC_URL_ARB_SEPOLIA || 'https://arbitrum-sepolia.gateway.tenderly.co',
+        'plume-mainnet': {
+            eid: EndpointId.PLUMEPHOENIX_V2_MAINNET,
+            url: process.env.RPC_URL_PLUME_MAINNET || 'https://rpc.plume.org',
             accounts,
         },
         hardhat: {

--- a/plume-oft-adapter-migration/layerzero.config.ts
+++ b/plume-oft-adapter-migration/layerzero.config.ts
@@ -5,14 +5,24 @@ import { OAppEnforcedOption } from '@layerzerolabs/toolbox-hardhat'
 
 import type { OmniPointHardhat } from '@layerzerolabs/toolbox-hardhat'
 
-const optimismContract: OmniPointHardhat = {
-    eid: EndpointId.OPTSEP_V2_TESTNET,
-    contractName: 'MyOFTUpgradeableMock', // Note: change this to 'MyOFTUpgradeable' or your production contract name
+const ethereumContract: OmniPointHardhat = {
+    eid: EndpointId.ETHEREUM_V2_MAINNET,
+    contractName: 'OrbitERC20OFTAdapterUpgradeable',
 }
 
-const arbitrumContract: OmniPointHardhat = {
-    eid: EndpointId.ARBSEP_V2_TESTNET,
-    contractName: 'MyOFTUpgradeableMock', // Note: change this to 'MyOFTUpgradeable' or your production contract name
+const plumeContract: OmniPointHardhat = {
+    eid: EndpointId.PLUMEPHOENIX_V2_MAINNET,
+    contractName: 'OrbitNativeOFTAdapterUpgradeable',
+}
+
+const existingEthereumPlumeOFTAdapterContract: OmniPointHardhat = {
+    eid: EndpointId.ETHEREUM_V2_MAINNET,
+    address: '0xbDA8a2285F4C3e75b37E467C4DB9bC633FfbD29d',
+}
+
+const plumeDummyContract: OmniPointHardhat = {
+    eid: EndpointId.PLUMEPHOENIX_V2_MAINNET,
+    contractName: 'PlumeOFTMock',
 }
 
 // To connect all the above chains to each other, we need the following pathways:
@@ -33,20 +43,27 @@ const EVM_ENFORCED_OPTIONS: OAppEnforcedOption[] = [
 // i.e. if you declare A,B there's no need to declare B,A
 const pathways: TwoWayConfig[] = [
     [
-        optimismContract, // Chain A contract
-        arbitrumContract, // Chain C contract
-        [['LayerZero Labs'], []], // [ requiredDVN[], [ optionalDVN[], threshold ] ]
-        [1, 1], // [A to B confirmations, B to A confirmations]
-        [EVM_ENFORCED_OPTIONS, EVM_ENFORCED_OPTIONS], // Chain C enforcedOptions, Chain A enforcedOptions
+        ethereumContract, // Chain A contract
+        plumeContract, // Chain C contract
+        [['LayerZero Labs'], []], // [ requiredDVN[], [ optionalDVN[], threshold ] ] // TODO update dvns
+        [1, 1], // [A to B confirmations, B to A confirmations] // TODO update confirmations
+        [EVM_ENFORCED_OPTIONS, EVM_ENFORCED_OPTIONS], // Chain C enforcedOptions, Chain A enforcedOptions // TODO confirm this
+    ],
+    [
+        // TODO this cannot be done by LZ -- Plume owns existing PlumeOFTAdapter contract on Ethereum
+        existingEthereumPlumeOFTAdapterContract, // Chain A contract
+        plumeDummyContract, // Chain C contract
+        [['LayerZero Labs'], []], // [ requiredDVN[], [ optionalDVN[], threshold ] ] // TODO update dvns
+        [1, 1], // [A to B confirmations, B to A confirmations] // TODO update confirmations
+        [EVM_ENFORCED_OPTIONS, EVM_ENFORCED_OPTIONS], // Chain C enforcedOptions, Chain A enforcedOptions // TODO confirm this
     ],
 ]
-// Note: you should not use the values 1, 1 for confirmations. Choose the right number of confirmations based on the finalization that you require from the source/destination chains.
 
 export default async function () {
     // Generate the connections config based on the pathways
     const connections = await generateConnectionsConfig(pathways)
     return {
-        contracts: [{ contract: optimismContract }, { contract: arbitrumContract }],
+        contracts: [{ contract: ethereumContract }, { contract: plumeContract }],
         connections,
     }
 }


### PR DESCRIPTION
## What's new in this PR?

This PR introduces the mock OFT that will be wired to the existing `PlumeOFTAdapter` to migrate funds to the new `OrbitERC20OFTAdapterUpgradeable` contract, along with deploy script
